### PR TITLE
arrondis sur les titres + texte en font weight normal

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -37,6 +37,7 @@
 
 .card-info{
   padding: 8px;
+  font-weight: normal;
 }
 
 .card-job{
@@ -70,7 +71,8 @@
 }
 
 .card-description {
-  color: #1b424A
+  color: #1b424A;
+  font-weight: normal;
 }
 
 .card-first-name {

--- a/app/assets/stylesheets/components/_show.scss
+++ b/app/assets/stylesheets/components/_show.scss
@@ -4,15 +4,15 @@
   gap: 16px;
 }
 
-.employee-container{
+// .employee-container{
   // width: 50%;
   // padding-top: 50px;
-}
+// }
 
-.panier-container{
+// .panier-container{
   // width: 50%;
   // padding-top: 10%;
-}
+// }
 
 .panier-lists-orders{
   display: flex;

--- a/app/assets/stylesheets/components/_title.scss
+++ b/app/assets/stylesheets/components/_title.scss
@@ -1,5 +1,6 @@
 .title{
   background-color: #3C87A6;
   color:white;
-  padding: 0 16px;
+  padding: 8px 16px;
+  border-radius: 30px;
 }

--- a/app/views/employees/_top.html.erb
+++ b/app/views/employees/_top.html.erb
@@ -1,8 +1,8 @@
 <section class="top-employee">
   <div class="container">
     <%= image_tag "top_employee.png", class:"top-image" %>
+    <h2><span class="title">Les tops employés</span></h2>
     <div class="cards">
-       <h2 ><span class="title">Les tops employés</span></h2>
      <% top_employees.each do |top_employee| %>
       <div class="card shadow">
         <div class="card-gradient">


### PR DESCRIPTION
Arrondis sur les titres pour être cohérent avec la mise en forme des cards et texte en font-weight normal pour que ce soit plus lisible:
![image](https://github.com/fabien-git/empnloc/assets/145602852/e5ea7311-a135-455a-a8cb-5d6a9834183e)
